### PR TITLE
Improve documentation.

### DIFF
--- a/System/Directory/Tree.hs
+++ b/System/Directory/Tree.hs
@@ -238,21 +238,25 @@ infixl 4 </$>
     ----------------------------
 
 
--- | build an AnchoredDirTree, given the path to a directory, opening the files
+-- | Build an AnchoredDirTree, given the path to a directory, opening the files
 -- using readFile. 
--- Uses `readDirectoryWith readFile` internally and has the effect of traversing the
+-- Uses @readDirectoryWith readFile@ internally and has the effect of traversing the
 -- entire directory structure. See `readDirectoryWithL` for lazy production
 -- of a DirTree structure.
 readDirectory :: FilePath -> IO (AnchoredDirTree String)
 readDirectory = readDirectoryWith readFile
 
 
--- | build a `DirTree` rooted at @p@ and using @f@ to fill the `file` field of `File` nodes.
+-- | Build a 'DirTree' rooted at @p@ and using @f@ to fill the 'file' field of 'File' nodes.
 --
--- The `FilePath` arguments to @f@ will be the full path to current file, and
+-- The 'FilePath' arguments to @f@ will be the full path to the current file, and
 -- will include the root @p@ as a prefix.
--- For example, you could use `return` for @f@ to return a tree of full file
--- paths, although the `build` function below already does this.
+-- For example, the following would return a tree of full 'FilePath's
+-- like \"..\/tmp\/foo\" and \"..\/tmp\/bar\/baz\":
+--
+-- > readDirectoryWith return "../tmp"
+--
+-- Note though that the 'build' function below already does this.
 readDirectoryWith :: (FilePath -> IO a) -> FilePath -> IO (AnchoredDirTree a)
 readDirectoryWith f p = buildWith' buildAtOnce' f p
 

--- a/System/Directory/Tree.hs
+++ b/System/Directory/Tree.hs
@@ -8,7 +8,7 @@
 -- Stability :  experimental
 -- Portability: portable
 --
---   Provides a simple data structure mirroring a directory tree on the 
+-- Provides a simple data structure mirroring a directory tree on the 
 -- filesystem, as well as useful functions for reading and writing file
 -- and directory structures in the IO monad. 
 -- 
@@ -240,15 +240,19 @@ infixl 4 </$>
 
 -- | build an AnchoredDirTree, given the path to a directory, opening the files
 -- using readFile. 
--- Uses `readDirectoryWith` internally and has the effect of traversing the
+-- Uses `readDirectoryWith readFile` internally and has the effect of traversing the
 -- entire directory structure. See `readDirectoryWithL` for lazy production
 -- of a DirTree structure.
 readDirectory :: FilePath -> IO (AnchoredDirTree String)
 readDirectory = readDirectoryWith readFile
 
 
--- | same as readDirectory but allows us to, for example, use 
--- ByteString.readFile to return a tree of ByteStrings.
+-- | build a `DirTree` rooted at @p@ and using @f@ to fill the `file` field of `File` nodes.
+--
+-- The `FilePath` arguments to @f@ will be the full path to current file, and
+-- will include the root @p@ as a prefix.
+-- For example, you could use `return` for @f@ to return a tree of full file
+-- paths, although the `build` function below already does this.
 readDirectoryWith :: (FilePath -> IO a) -> FilePath -> IO (AnchoredDirTree a)
 readDirectoryWith f p = buildWith' buildAtOnce' f p
 
@@ -323,7 +327,7 @@ type UserIO a = FilePath -> IO a
 type Builder a = UserIO a -> FilePath -> IO (DirTree a)
 
 -- remove non-existent file errors, which are artifacts of the "non-atomic" 
--- nature of traversing a system firectory tree:
+-- nature of traversing a system directory tree:
 buildWith' :: Builder a -> UserIO a -> FilePath -> IO (AnchoredDirTree a)
 buildWith' bf' f p = 
     do tree <- bf' f p


### PR DESCRIPTION
Explain the `FilePath` argument to builder function passed to `readDirectoryWith`. With the old docs I didn't understand what the `FilePath` argument would be, and so I had to run examples to figure it out. I hope these updated docs will be more helpful.

Also, the indentation on the first paragraph of the module-level docs was making Haddock ignore the first line of that paragraph, so I removed the indentation.

I did not rebuild the Haddock docs to test this change.